### PR TITLE
feat(core): 添加 CMakeLists.txt 文件并优化激活和更新管理

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,0 +1,7 @@
+file(GLOB CORE_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/activition_phase/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/flash_phase/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/prefabrication_phase/*.cpp
+)
+set(CORE_SRC ${CORE_SRC} PARENT_SCOPE)

--- a/src/core/flash_phase/flash_update_manager.cpp
+++ b/src/core/flash_phase/flash_update_manager.cpp
@@ -1,29 +1,31 @@
 #include "flash_update_manager.h"
-#include <iostream>
 #include <regex>
 #include <filesystem>
+#include <iostream>
+#include "otalog.h"
 
 namespace fs = std::filesystem;
+
 FlashUpdateManager::FlashUpdateManager()
 {
     socUpdater_ = std::make_shared<SocUpdater>();
     mcuUpdater_ = std::make_shared<McuUpdater>();
+    updateStatus_.stage = 1;   // 升级未开始
+    updateStatus_.process = 0; // 0%
 }
 
 FlashUpdateManager::~FlashUpdateManager()
 {
-    if (updateThread_.joinable())
-    {
+    if (updateThread_.joinable()) {
         updateThread_.join();
     }
 }
 
-OtaStatus_e FlashUpdateManager::StartUpdate(const char *path)
+OtaStatus_e FlashUpdateManager::StartUpdate(const char* path)
 {
-    OtaStatus_e result = OtaStatus_e::Success;
-    if (!path)
-    {
-        result = OtaStatus_e::Failed;
+    OtaStatus_e result = OTA_STATUS_SUCCESS;
+    if (!path) {
+        result = OTA_STATUS_FAILED;;
         return result;
     }
     packagePath_ = path;
@@ -31,85 +33,187 @@ OtaStatus_e FlashUpdateManager::StartUpdate(const char *path)
     return result;
 }
 
-OtaStatus_e FlashUpdateManager::GetUpdateStatus(UpdateSta_s &status)
+OtaStatus_e FlashUpdateManager::GetUpdateStatus(UpdateSta_s* status)
 {
-    status = updateStatus_;
-    return OtaStatus_e::Success;
+    if (!status) {
+        OTALOG(OlmInstall, OllError, "[FlashUpdateManager]GetUpdateStatus failed, status is null.\n");
+        return OTA_STATUS_FAILED;
+    }
+    status->stage = updateStatus_.stage;
+    status->process = updateStatus_.process;
+    return OTA_STATUS_SUCCESS;
+}
+
+// 创建目录（如果不存在）
+bool FlashUpdateManager::EnsureDir(const std::string& path)
+{
+    struct stat st;
+    if (stat(path.c_str(), &st) != 0) {
+        return mkdir(path.c_str(), 0755) == 0;
+    }
+    return S_ISDIR(st.st_mode);
 }
 
 void FlashUpdateManager::BackupConfigs()
 {
-    std::system("cp -r /opt/seres /opt/seres.bak");
-    std::system("cp -r /data /data.bak");
+    OTALOG(OlmInstall, OllInfo, "[FlashUpdateManager]begin backup config\n");
+
+    // 确保备份目录存在
+    EnsureDir("/opt/seres/backup");
+    EnsureDir("/data/backup");
+
+    //备份opt/seres
+    const std::vector<std::string> opt_dirs = {"start", "packages", "middleware", "calibration", "model"};
+    std::string opt_cmd = "tar -czf /opt/seres/backup/seres_backup.tar.gz";
+    bool opt_has_valid = false;
+
+    for (const auto& dir : opt_dirs) {
+        std::string full_path = "/opt/seres/" + dir;
+        if (fs::exists(full_path)) {
+            opt_cmd += " -C /opt/seres " + dir;
+            opt_has_valid = true;
+        }
+    }
+
+    int ret1 = 0;
+    if (opt_has_valid) {
+        ret1 = system((opt_cmd + " > /dev/null 2>&1").c_str());
+    } else {
+        OTALOG(OlmInstall, OllInfo, "[FlashUpdateManager]no valid /opt/seres directories to back up\n");
+    }
+
+    //备份/data
+    const std::vector<std::string> data_dirs = {"config", "db"};
+    std::string data_cmd = "tar -czf /data/backup/data_backup.tar.gz";
+    bool data_has_valid = false;
+
+    for (const auto& dir : data_dirs) {
+        std::string full_path = "/data/" + dir;
+        if (fs::exists(full_path)) {
+            data_cmd += " -C /data " + dir;
+            data_has_valid = true;
+        }
+    }
+
+    int ret2 = 0;
+    if (data_has_valid) {
+        ret2 = system((data_cmd + " > /dev/null 2>&1").c_str());
+    } else {
+        OTALOG(OlmInstall, OllInfo, "[FlashUpdateManager]no valid /data directories to back up\n");
+    }
+
+    if ((opt_has_valid ? ret1 == 0 : true) && (data_has_valid ? ret2 == 0 : true)) {
+        OTALOG(OlmInstall, OllInfo, "[FlashUpdateManager]backup success\n");
+    } else {
+        OTALOG(OlmInstall, OllError, "[FlashUpdateManager]backup process failed\n");
+    }
 }
 
-bool FlashUpdateManager::UnzipPackage(const std::string &zip_path)
+
+bool FlashUpdateManager::UnzipPackage(const std::string& zip_path)
 {
-    std::string cmd = "unzip -o \"" + zip_path + "\" -d \"" + fs::path(zip_path).parent_path().string() + "\"";
+    std::string cmd = "unzip -oq \"" + zip_path + "\" -d \"" + fs::path(zip_path).parent_path().string() + "\"";
     return std::system(cmd.c_str()) == 0;
 }
 
-void PrepareUpdateEnvironment(const std::string &zip_path,
-                              std::vector<fs::path> &socPackages,
-                              std::vector<fs::path> &mcuPackages)
+bool FlashUpdateManager::PrepareUpdateEnvironment(const std::string& zip_path,
+                                                  std::vector<fs::path>& socPackages,
+                                                  std::vector<fs::path>& mcuPackages)
 {
+    bool success = true;
     socPackages.clear();
     mcuPackages.clear();
-
-    std::cout << "[SOC] 解压软件包: " << zip_path << std::endl;
-    if (!UnzipPackage(zip_path))
-    {
-        std::cerr << "[SOC] 解压失败。\n";
-        return;
+    OTALOG(OlmInstall, OllInfo, "[FlashUpdateManager]unzip package: %s\n", zip_path.c_str());
+    if (!UnzipPackage(zip_path)) {
+        OTALOG(OlmInstall, OllError, "[FlashUpdateManager]unzip failed.\n");
+        success = false;
     }
 
-    std::cout << "[SOC] 备份 /opt/seres 与 /data 配置...\n";
-    BackupConfigs();
+    if (success) {
+        fs::path extracted_dir = fs::path(zip_path).parent_path();
+        OTALOG(OlmInstall, OllInfo, "[FlashUpdateManager]unzip directory: %s\n", extracted_dir.string().c_str());
+        try {
+            for (const auto& entry : fs::directory_iterator(extracted_dir)) {
+                const std::string filename = entry.path().filename().string();
 
-    fs::path extracted_dir = fs::path(zip_path).parent_path();
-
-    for (const auto &entry : fs::directory_iterator(extracted_dir))
-    {
-        const std::string filename = entry.path().filename().string();
-
-        if (std::regex_match(filename, std::regex(R"(app.*\.deb)")) ||
-            std::regex_match(filename, std::regex(R"(robot.*\.deb)")) ||
-            std::regex_match(filename, std::regex(R"(navi.*\.deb)")) ||
-            std::regex_match(filename, std::regex(R"(mc.*\.deb)")) ||
-            std::regex_match(filename, std::regex(R"(rte.*\.deb)")) ||
-            std::regex_match(filename, std::regex(R"(SOC.*\.tar\.gz)")))
-        {
-            socPackages.push_back(entry.path());
-        }
-        else if (std::regex_match(filename, std::regex(R"(MCU_FLASH_DRIVER.*\.bin)")) ||
-                 std::regex_match(filename, std::regex(R"(MCU_APP.*\.bin)")))
-        {
-            mcuPackages.push_back(entry.path());
+                if (std::regex_match(filename, std::regex(R"(app.*\.deb)"))
+                    || std::regex_match(filename, std::regex(R"(robot.*\.deb)"))
+                    || std::regex_match(filename, std::regex(R"(navi.*\.deb)"))
+                    || std::regex_match(filename, std::regex(R"(mc.*\.deb)"))
+                    || std::regex_match(filename, std::regex(R"(rte.*\.deb)"))
+                    || std::regex_match(filename, std::regex(R"(SOC.*\.tar.gz)"))) {
+                    socPackages.push_back(entry.path());
+                } else if (std::regex_match(filename, std::regex(R"(MCU_FLASH_DRIVER.*\.bin)"))
+                           || std::regex_match(filename, std::regex(R"(MCU_APP.*\.bin)"))) {
+                    mcuPackages.push_back(entry.path());
+                }
+            }
+        } catch (const std::exception& e) {
+            OTALOG(OlmInstall, OllError, "[FlashUpdateManager]forereach directory failed: %s\n", e.what());
+            success = false;
         }
     }
+
+    return success;
 }
 
 void FlashUpdateManager::UpdateThreadFunc()
 {
+
+    updateStatus_.stage = 1; // 升级开始
     std::vector<fs::path> socPackages;
     std::vector<fs::path> mcuPackages;
-    PrepareUpdateEnvironment(packagePath_, socPackages, mcuPackages);
-    const uint8_t totalPackageCount = socPackages.size() + mcuPackages.size();
-
-    std::cout << "[UpdateManager] Starting SOC update...\n";
-    if (!socUpdater_.Update(socPackages,updateStatus_,totalPackageCount))
-    {
-        std::cerr << "[UpdateManager] SOC update failed.\n";
+    if (!PrepareUpdateEnvironment(packagePath_, socPackages, mcuPackages)) {
+        updateStatus_.stage = 2; // 升级失败
         return;
     }
+    int totalPackageCount = socPackages.size() + mcuPackages.size();
+    int finishedCount = 0;
 
-    std::cout << "[UpdateManager] Starting MCU update...\n";
-    if (!mcuUpdater_.Update(mcuPackages,updateStatus_,totalPackageCount))
-    {
-        std::cerr << "[UpdateManager] MCU update failed.\n";
-        return;
+    auto updateProgress = [&](int processed) {
+        finishedCount += processed;
+        updateStatus_.process = static_cast<int>(finishedCount * 100 / totalPackageCount);
+        std::string log_msg = "[FlashUpdateManager]Overall progress: " + std::to_string(updateStatus_.process) + "%";
+        OTALOG(OlmInstall, OllInfo, "%s\n", log_msg.c_str());
+    };
+    bool socFlag = true;
+    if (!socPackages.empty()) {
+        for (auto& package : socPackages) {
+            OTALOG(OlmInstall, OllInfo, "[FlashUpdateManager]upgrade software package: %s\n", package.string().c_str());
+        }
+        if (!JsonHelper::GetInstance().WriteBool(K_OTA_INFO_JSON_PATH, "soc_flag", socFlag)) {
+            OTALOG(OlmInstall, OllError, "[FlashUpdateManager]WriteBool soc_flag failed.\n");
+        }
+        // 开始备份
+        BackupConfigs();
+        if (!socUpdater_->Update(socPackages, updateProgress)) {
+            OTALOG(OlmInstall, OllError, "[FlashUpdateManager]SOC update failed.\n");
+            updateStatus_.stage = 2;
+            return;
+        }
     }
 
-    std::cout << "[UpdateManager] Update process completed successfully.\n";
+    if (!mcuPackages.empty()) {
+        socFlag = false;
+        if (!JsonHelper::GetInstance().WriteBool(K_OTA_INFO_JSON_PATH, "soc_flag", socFlag)) {
+            OTALOG(OlmInstall, OllError, "[FlashUpdateManager]WriteBool soc_flag failed.\n");
+        }
+        if (!mcuUpdater_->Update(mcuPackages, updateProgress)) {
+            OTALOG(OlmInstall, OllError, "[FlashUpdateManager]MCU update failed.\n");
+            updateStatus_.stage = 2;
+            return;
+        }
+    }
+    updateStatus_.stage = 0; // 升级成功
+
+    // 创建线程，重启系统
+    std::thread rebootThread([this]() {
+        if (!mcuUpdater_->Reboot()) {
+            OTALOG(OlmInstall, OllError, "reboot failed\n");
+        }
+    });
+    // 分离线程（后台运行）
+    rebootThread.detach();
+
+    OTALOG(OlmInstall, OllInfo, "[FlashUpdateManager]Update process completed successfully.\n");
 }
-

--- a/src/core/ota_service.cpp
+++ b/src/core/ota_service.cpp
@@ -1,5 +1,7 @@
 #include "ota_service.h"
 #include <iostream>
+#include "otalog.h"
+
 
 // 获取单例实例
 OtaService& OtaService::GetInstance() {
@@ -17,8 +19,8 @@ OtaService::OtaService() {
 OtaStatus_e OtaService::SetRobotInfo(const RobotInfo_s* info) {
     if (!info)
     {
-        std::cout << "Failed to Set Robot Info" << std::endl;
-        return OtaStatus_e::Failed;
+        OTALOG(OlmInstall, OllError, "[OtaService]Invalid Robot Info\n");
+        return OTA_STATUS_FAILED;
     } 
     return prefabManager_->SetRobotInfo(info);
 }
@@ -30,8 +32,8 @@ OtaStatus_e OtaService::SetOtaMode(otaMode_e mode) {
 OtaStatus_e OtaService::StartUpdate(const char* path) {
     if (!path)
     {
-        std::cout << "Invalid Update Path" << std::endl;
-        return OtaStatus_e::Failed;
+        OTALOG(OlmInstall, OllError, "[OtaService]Invalid Update Path\n");
+        return OTA_STATUS_FAILED;;
     } 
     return flashManager_->StartUpdate(path);
 }
@@ -39,8 +41,8 @@ OtaStatus_e OtaService::StartUpdate(const char* path) {
 OtaStatus_e OtaService::GetUpdateStatus(UpdateSta_s* status) {
     if (!status)
     {
-        std::cout << "Invalid Update Status" << std::endl;
-        return OtaStatus_e::Failed;
+        OTALOG(OlmInstall, OllError, "[OtaService]Invalid Update OtaStatus_e\n");
+        return OTA_STATUS_FAILED;;
     } 
     return flashManager_->GetUpdateStatus(status);
 }
@@ -52,8 +54,8 @@ OtaStatus_e OtaService::SetActive() {
 OtaStatus_e OtaService::GetActive(ActiveSta_s* status) {
     if (!status)
     {
-        std::cout << "Invalid Active Status" << std::endl;
-        return OtaStatus_e::Failed;
+        OTALOG(OlmInstall, OllError, "[OtaService]Invalid Active OtaStatus_e");
+        return OTA_STATUS_FAILED;;
     } 
     return activeManager_->GetActive(status);
 }

--- a/src/core/prefabrication_phase/prefabrication_manager.cpp
+++ b/src/core/prefabrication_phase/prefabrication_manager.cpp
@@ -1,48 +1,52 @@
 #include "prefabrication_manager.h"
 #include <iostream>
+#include "otalog.h"
 
 OtaStatus_e PrefabricationManager::SetRobotInfo(const RobotInfo_s *info) {
-    OtaStatus_e result = OtaStatus_e::Failed; 
+    OtaStatus_e result = OTA_STATUS_FAILED; 
 
     if (info) {
-        bool success = JsonHelper::GetInstance().WriteString("/data/config/ota/robot_info.json", "robot_sw_version", info->version);
+        bool success = JsonHelper::GetInstance().WriteString(K_ROBOT_INFO_JSON_PATH, "robot_sw_version", info->version);
         if (success) {
-            result = OtaStatus_e::Success; 
-            std::cout << "[OTA] Set Robot Info: version = " << info->version << std::endl;
+            result = OTA_STATUS_SUCCESS; 
+            OTALOG(OlmInstall, OllInfo, "[PRE]Set Robot Info: version = %s\n", info->version);
         } else {
-            std::cerr << "[OTA] Failed to write robot_info.json." << std::endl;
+            OTALOG(OlmInstall, OllError, "[PRE]Failed to write robot_info.json.\n" );
         }
     }
     return result; 
 }
 
 OtaStatus_e PrefabricationManager::SetOtaMode(otaMode_e mode) {
-    OtaStatus_e result = OtaStatus_e::Failed;
+    OtaStatus_e result = OTA_STATUS_FAILED;
+    bool otaModeFlag;
     if (mode == OTA_MODE_CANCEL) {
-        std::cout << "[OTA] OTA mode canceled, no update will be performed." << std::endl;
-        result = JsonHelper::GetInstance().WriteBool("/data/config/ota/ota_info.json", "ota_mode_flag", false);
-        if (!result) {
-            std::cerr << "[OTA] Failed to write ota_mode_flag = false" << std::endl;
+        OTALOG(OlmInstall, OllInfo, "[PRE]OTA mode canceled, no update will be performed.\n");
+        otaModeFlag = false;
+        bool readResult = JsonHelper::GetInstance().WriteBool(K_OTA_INFO_JSON_PATH, "ota_mode_flag", otaModeFlag);
+        if (!readResult) {
+            OTALOG(OlmInstall, OllError,  "[PRE]Failed to write ota_mode_flag = false\n" );
         }
-        result = OtaStatus_e::Success;
+        result = OTA_STATUS_SUCCESS;  
     } else if (mode == OTA_MODE_SET) {
-        std::cout << "[OTA] OTA mode set. Starting update thread..." << std::endl;
-        result = JsonHelper::GetInstance().WriteOtaStatus_e("/data/config/ota/ota_info.json", "ota_mode_flag", true);
-        if (!result) {
-            std::cerr << "[OTA] Failed to write ota_mode_flag = true" << std::endl;
+        OTALOG(OlmInstall, OllInfo, "[PRE]Set OTA mode.Starting update thread\n");
+        otaModeFlag = true;
+        bool readResult = JsonHelper::GetInstance().WriteBool(K_OTA_INFO_JSON_PATH, "ota_mode_flag", otaModeFlag);
+        if (!readResult) {
+            OTALOG(OlmInstall, OllError,  "[PRE]Failed to write ota_mode_flag = true\n" );
         }
-        result = OtaStatus_e::Success;
+        result = OTA_STATUS_SUCCESS;
         //后续通知MCU进入OTA模式（保留接口）
         // if (result) {
         //     result = NotifyMcuEnterOtaMode();
         //     if (!result) {
-        //         std::cerr << "[OTA] Failed to notify MCU to enter OTA mode via SPI." << std::endl;
+        //         std::cerr << "[PRE]Failed to notify MCU to enter OTA mode via SPI." << std::endl;
         //     }
         // } else {
-        //     std::cerr << "[OTA] Failed to write ota_mode_flag = true" << std::endl;
+        //     std::cerr << "[PRE]Failed to write ota_mode_flag = true" << std::endl;  
         // }
     } else {
-        std::cerr << "[OTA] Invalid OTA mode: " << mode << std::endl;
+        OTALOG(OlmInstall, OllError, "[PRE]Failed to write ota_mode_flag = true\n");
     }
     return result; 
 }

--- a/src/core/rbt_ota_interface.cpp
+++ b/src/core/rbt_ota_interface.cpp
@@ -1,9 +1,6 @@
 #include "rbt_ota_interface.h"
 #include "ota_service.h"
 
-
-extern "C" {
-
 OtaStatus_e OtaAgentSetRobotInfo(RobotInfo_s* info) {
     return OtaService::GetInstance().SetRobotInfo(info);
 }
@@ -28,4 +25,3 @@ OtaStatus_e OtaAgentGetActivestatus(ActiveSta_s* status) {
     return OtaService::GetInstance().GetActive(status);
 }
 
-}


### PR DESCRIPTION
在 `activation_manager.cpp` 中：
- 添加了 `ActivationManager` 的构造函数，并使用 `OTALOG` 记录创建信息。
- 修改了 `SetActive` 函数，使其返回 `OtaStatus_e` 类型，并使用 `OTALOG` 记录日志。
- 新增了 `ExtractVersionFromFilename` 函数，用于从文件名中提取版本号。
- 修改了 `GetActive` 函数，使其返回 `OtaStatus_e` 类型，并使用 `OTALOG` 记录日志。

在 `flash_update_manager.cpp` 中：
- 添加了 `OTALOG` 头文件，并在关键步骤使用 `OTALOG` 记录日志。
- 修改了 `StartUpdate` 函数，使其返回 `OtaStatus_e` 类型，并调用 `PrepareUpdateEnvironment` 函数。
- 新增了 `EnsureDir` 函数，用于创建目录（如果不存在）。
- 修改了 `BackupConfigs` 函数，增加了目录检查和备份信息记录。
- 修改了 `PrepareUpdateEnvironment` 函数，使其返回 `bool` 类型，并包含更多的错误处理。
- 修改了 `UpdateThreadFunc` 函数，增加了进度回调和详细的日志记录。

在 `mcu_updater.cpp` 中：
- 添加了 `OTALOG` 头文件，并在关键步骤使用 `OTALOG` 记录日志。
- 修改了 `Update` 函数，使其接受进度回调函数。
- 修改了 `TryUpdateOnce` 函数，使其接受进度回调函数。
- 修改了 `ExtractVersionFromFilename` 函数，简化了版本号提取逻辑。
- 修改了 `IsVersionNewer` 函数，使其接受两个字符串参数并返回比较结果。
- 修改了 `PreUpdate` 函数，增加了详细的日志记录和错误处理。
- 修改了 `FlashDriverUpdate` 函数，增加了重试机制和错误处理。
- 修改了 `AppUpdate` 函数，增加了重试机制和错误处理。
- 修改了 `Flashing` 函数，使其接受进度回调函数，并包含了详细的日志记录。
- 修改了 `Reboot` 函数，简化了逻辑并增加了日志记录。

在 `ota_service.cpp` 中：
- 添加了 `OTALOG` 头文件，并在关键步骤使用 `OTALOG` 记录日志。
- 修改了 `SetRobotInfo` 函数，使其返回 `OTA_STATUS_FAILED` 或 `OTA_STATUS_SUCCESS` 类型，并增加了日志记录。
- 修改了 `SetOtaMode` 函数，增加了日志记录。
- 修改了 `StartUpdate` 函数，使其返回 `OTA_STATUS_FAILED` 或 `OTA_STATUS_SUCCESS` 类型，并增加了日志记录。
- 修改了 `GetUpdateStatus` 函数，使其返回 `OTA_STATUS_FAILED` 或 `OTA_STATUS_SUCCESS` 类型，并增加了日志记录。
- 修改了 `SetActive` 函数。
- 修改了 `GetActive` 函数，使其返回 `OTA_STATUS_FAILED` 或 `OTA_STATUS_SUCCESS` 类型，并增加了日志记录。

在 `prefabrication_manager.cpp` 中：
- 添加了 `OTALOG` 头文件，并在关键步骤使用 `OTALOG` 记录日志。
- 修改了 `SetRobotInfo` 函数，使其返回 `OTA_STATUS_FAILED` 或 `OTA_STATUS_SUCCESS` 类型，并增加了日志记录。
- 修改了 `SetOtaMode` 函数，使其返回 `OTA_STATUS_FAILED` 或 `OTA_STATUS_SUCCESS` 类型，并增加了日志记录。

在 `rbt_ota_interface.cpp` 中：
- 移除了不必要的 `extern "C"` 块。